### PR TITLE
Fix My Nightly Check

### DIFF
--- a/app/src/main/java/wbl/egr/uri/sensorcollector/fragments/TestingFragment.java
+++ b/app/src/main/java/wbl/egr/uri/sensorcollector/fragments/TestingFragment.java
@@ -119,35 +119,21 @@ public class TestingFragment extends Fragment {
                         boolean sensorsEnabled = SettingsActivity.getBoolean(getActivity(), SettingsActivity.KEY_SENSOR_ENABLE, false);
                         int audioResult = checkAudio();
                         int sensorResult = checkSensors();
+                        boolean audioPassed = audioEnabled && (audioResult == 0);
+                        boolean sensorPassed = sensorsEnabled && (sensorResult == 0);
 
-                        if(audioEnabled && sensorsEnabled)
-                        {
-                            if (audioResult == 0 && sensorResult == 0)
+                        if (audioPassed) {
+                            if (sensorPassed) {
                                 passed();
-                            else if(audioResult != 0 && sensorResult != 0)
+                            } else {
+                                sensorsFailed(sensorResult);
+                            }
+                        } else {
+                            if (sensorPassed) {
+                                audioFailed(audioResult);
+                            } else {
                                 bothFailed();
-                            else if(audioResult != 0 && sensorResult == 0)
-                                audioFailed(audioResult);
-                            else
-                                sensorsFailed(sensorResult);
-                        }
-                        else if(audioEnabled && !sensorsEnabled)
-                        {
-                            if(audioResult == 0)
-                                passed();
-                            else
-                                audioFailed(audioResult);
-                        }
-                        else if(!audioEnabled && sensorsEnabled)
-                        {
-                            if(sensorResult == 0)
-                                passed();
-                            else
-                                sensorsFailed(sensorResult);
-                        }
-                        else
-                        {
-
+                            }
                         }
                     }
                 });
@@ -228,9 +214,6 @@ public class TestingFragment extends Fragment {
                     .onNegative(new MaterialDialog.SingleButtonCallback() {
                         @Override
                         public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                            AudioRecordManager.start(getActivity(), AudioRecordManager.ACTION_AUDIO_CANCEL);
-                            AudioRecordManager.start(getActivity(), AudioRecordManager.ACTION_AUDIO_START);
-
                             new Thread(new Runnable() {
                                 @Override
                                 public void run() {

--- a/app/src/main/java/wbl/egr/uri/sensorcollector/services/BandCollectionService.java
+++ b/app/src/main/java/wbl/egr/uri/sensorcollector/services/BandCollectionService.java
@@ -408,6 +408,7 @@ public class BandCollectionService extends Service {
             FBSensorManager bandSensorManager = mBandClient.getSensorManager();
             try
             {
+                log("Set state to streaming");
                 state = STATE_STREAMING;
                 updateNotification("STREAMING", android.R.drawable.presence_online);
                 // XXX accel listener does nothing currently
@@ -442,6 +443,7 @@ public class BandCollectionService extends Service {
             try {
                 bandSensorManager.stop();
                 state = STATE_DISCONNECTED;
+                log("Set state to disconnected");
                 updateNotification("OFF", android.R.drawable.presence_offline);
                 mServer.stop();
             } catch (Exception e) {


### PR DESCRIPTION
Make My Nightly Check fail if the sensor buttons are flipped off so that the "restart" button flips them back on.